### PR TITLE
Fix error in getAltBorderPolygon

### DIFF
--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -140,7 +140,7 @@ class HSSHexagonalGrid extends HexagonalGrid {
 		// this is the only real change from the foundry default
 		const points = (
 			this.columnar ? this.constructor.FLAT_HEX_BORDERS[w] : this.constructor.POINTY_HEX_BORDERS[w]
-		).map(p => [1 - p[0], 1 - p[1]]);
+		)?.map(p => [1 - p[0], 1 - p[1]]);
 
 		if (w !== h || !points) return null;
 		const p2 = p / 2;


### PR DESCRIPTION
Use an option chain to flip the polygon in the alternate border method.
Without the chain, the resize canvas animation will cause an error and
lock up the token and potentially the canvas until a reload.
