### PR TITLE
Drag Ruler Compatibility

### DIFF
--- a/src/hss.js
+++ b/src/hss.js
@@ -1,14 +1,16 @@
 import { registerSettings, renderSettingsConfig } from "./modules/settings";
 import { hitAreaDraw, hitAreaUpdate, pivotToken } from "./modules/hitarea";
 import { registerBorderWrappers, moveBorderLayer } from "./modules/border";
-import { registerGridWrapper, extendHexBorders } from "./modules/grid";
+import { registerGridWrapper, extendHexBorders, isAltOrientation } from "./modules/grid";
 import { extendTokenConfig } from "./modules/token-config";
 
 Hooks.once("init", () => {
 	console.log("hex-size-support | Initializing module");
 	registerSettings();
 	extendHexBorders();
-	const API = {};
+	const API = {
+		isAltOrientation,
+	};
 	game.modules.get("hex-size-support").api = API;
 });
 

--- a/src/hss.js
+++ b/src/hss.js
@@ -8,6 +8,8 @@ Hooks.once("init", () => {
 	console.log("hex-size-support | Initializing module");
 	registerSettings();
 	extendHexBorders();
+	const API = {};
+	game.modules.get("hex-size-support").api = API;
 });
 
 Hooks.once("libWrapper.Ready", () => {


### PR DESCRIPTION
Drag ruler's v10 update didn't touch hex grids and so this module is incompatible. This PR is a placeholder for implementing any (hopefully few) changes necessary for drag ruler, such as helper functions.

Implementing any real changes is currently blocked by https://github.com/manuelVo/foundryvtt-drag-ruler/issues/236 as the resolution to that determines what the resolution to compatibility with this module needs to look like.
