### PR TITLE
add the ability to hide a token's border and  update scale steps

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -3,7 +3,7 @@
 		"settings": {
 			"alwaysShowBorder": {
 				"name": "Always Show Border",
-				"hint": "Always render the token's border."
+				"hint": "Always render the token's border. Overriden if a Token has 'Hide Border' checked."
 			},
 			"altOrientationDefault": {
 				"name": "Flip default orientation",
@@ -56,6 +56,10 @@
 			"altOrientation": {
 				"label": "Alternate Orientation",
 				"notes": "Flip the orientation of the token"
+			},
+			"hideBorder": {
+				"label": "Hide Border",
+				"notes": "Hide the token's border. Overrides Module setting 'Always Show Border.'"
 			}
 		}
 	}

--- a/src/modules/border.js
+++ b/src/modules/border.js
@@ -11,10 +11,12 @@ export function registerBorderWrappers() {
 			/** @type boolean */
 			const fill_border = game.settings.get("hex-size-support", "fillBorder");
 			const options = {};
-			if (always_show) options.hover = true;
+			
+			/** @type boolean **/
+			const token_hide_border = this.document.getFlag("hex-size-support", "hideBorder");
 
 			this.border.clear();
-			if (!this.isVisible) return;
+			if (!this.isVisible || token_hide_border) return;
 			const borderColor = this._getBorderColor(options);
 			if (borderColor == null) return;
 

--- a/src/modules/token-config.js
+++ b/src/modules/token-config.js
@@ -26,6 +26,19 @@ export function extendTokenConfig(app, $el) {
 			}>
 		</div>
 	</div>
+	<div class="form-group slim">
+		<label>${game.i18n.localize("hex-size-support.tokenConfig.hideBorder.label")}</label>
+		<div class="form-fields">
+			<input type="checkbox" step="1" name="flags.hex-size-support.hideBorder" ${
+				app.object.getFlag("hex-size-support", "hideBorder") ? "checked" : ""
+			}>
+		</div>
+	</div>
 	`);
+	
+	let x = $el.find("[name=scale]");
+	x.attr('max', Number(5.0));
+	x.attr('step', Number(0.01)); 
+
 	app.setPosition();
 }


### PR DESCRIPTION
* Add token setting to hide token border that overrides the module setting `Always Show Border`
* Update Token's `Scale` input to allow a max of 5 and to reduce the steps to `0.01`