### PR TITLE
Update HSS for v11 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,7 @@ root = true
 
 [*]
 indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
 
     # Run the compilation step
     - run: npm clean-install
@@ -17,18 +20,18 @@ jobs:
 
     # Remove the 'v' from the tag for versioning
     - id: get_version
-      uses: battila7/get-version-action@v2
+      run: |
+        echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        echo "FOUNDRY_MANIFEST=https://github.com/${{github.repository}}/releases/latest/download/module.json" >> $GITHUB_ENV
+        echo "FOUNDRY_DOWNLOAD=https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip" >> $GITHUB_ENV
 
     # Substitute the Manifest and Download URLs in the module.json
     - name: Substitute Manifest and Download Links For Versioned Ones
       id: sub_manifest_link_version
-      uses: microsoft/variable-substitution@v1
+      uses: restackio/update-json-file-action@v2.1
       with:
-        files: './dist/module.json'
-      env:
-        version: ${{steps.get_version.outputs.version-without-v}}
-        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
-        download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+        file: './dist/module.json'
+        fields: "{\"version\": \"${{env.VERSION}}\", \"manifest\": \"${{env.FOUNDRY_MANIFEST}}\", \"download\": \"${{env.FOUNDRY_DOWNLOAD}}\"}"
 
     # Create a zip file with all files required by the module to add to the release
     - name: Zip Files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     # Substitute the Manifest and Download URLs in the module.json
     - name: Substitute Manifest and Download Links For Versioned Ones
       id: sub_manifest_link_version
-      uses: restackio/update-json-file-action@v2.1
+      uses: restackio/update-json-file-action@2.1
       with:
         file: './dist/module.json'
         fields: "{\"version\": \"${{env.VERSION}}\", \"manifest\": \"${{env.FOUNDRY_MANIFEST}}\", \"download\": \"${{env.FOUNDRY_DOWNLOAD}}\"}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Jetbrains IDE files
 .idea/**
+client
+common
 
 node_modules
 dist

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,10 @@
 {
-  "compilerOptions": {
-    "target": "es13",
-    "types": ["@league-of-foundry-developers/foundry-vtt-types"]
-  }
+	"compilerOptions": {
+		"module": "es2022",
+		"target": "ES2022",
+		"moduleResolution": "bundler",
+		"skipLibCheck": true
+	},
+	"exclude": ["node_modules", "dist"],
+	"include": ["src", "client", "common"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.1.6",
       "license": "MIT",
       "devDependencies": {
-        "@league-of-foundry-developers/foundry-vtt-types": "^9.280.0",
         "@rollup/plugin-node-resolve": "^13.0.5",
         "prettier": "^2.4.1",
         "rollup": "^2.58.0",
@@ -113,161 +112,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types": {
-      "version": "9.280.0",
-      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.280.0.tgz",
-      "integrity": "sha512-Dv8/+kgAnI2F5snSWcnMnZsgO/87AFyBruflluZkWDbP7Pm5qi32GlNYCDEg7HMKybzyKmgLV2qXMmYPHtCT7w==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/graphics-smooth": "0.0.22",
-        "@types/jquery": "~3.5.9",
-        "@types/simple-peer": "~9.11.1",
-        "handlebars": "4.7.7",
-        "pixi-particles": "4.3.1",
-        "pixi.js": "5.3.11",
-        "socket.io-client": "4.3.2",
-        "tinymce": "5.10.1"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/constants": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.3.tgz",
-      "integrity": "sha512-h/0Sf6ak0f0bLKo87CQDAUi9+VbAerJi8uKsq4d1DyXYGCNizjIiBVBUfWAPmzJ7JQ79hMn3fYXWCzlp4flKfw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/core": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.3.tgz",
-      "integrity": "sha512-537nYn5RmXrjSiaDUa5O6Rg72JifoAuKDw2YtAlg9LvoY8jKo2ZP3NvIqrMo2GIjD/I2mznGcU+s9VPzP8lBCQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/offscreencanvas": "^2019.6.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.5.3",
-        "@pixi/extensions": "6.5.3",
-        "@pixi/math": "6.5.3",
-        "@pixi/runner": "6.5.3",
-        "@pixi/settings": "6.5.3",
-        "@pixi/ticker": "6.5.3",
-        "@pixi/utils": "6.5.3"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/display": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.3.tgz",
-      "integrity": "sha512-Oq51rmnaqbv08z+CuSi75GPKyrzrDi96A1J7mNMJMq4CV6zrwSzCrjo6fcK1Fa47fHRbnkvOqhMQ5aR6NV09MA==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/math": "6.5.3",
-        "@pixi/settings": "6.5.3",
-        "@pixi/utils": "6.5.3"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/graphics": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.3.tgz",
-      "integrity": "sha512-jALPefMEadpW4A/ryf3ALo+a8RY3vPcSUAuSu+W60zBhWcLas5O7doNmdwkBNSp06sYalvdl64xs1oBwaoxWQg==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.3",
-        "@pixi/core": "6.5.3",
-        "@pixi/display": "6.5.3",
-        "@pixi/math": "6.5.3",
-        "@pixi/sprite": "6.5.3",
-        "@pixi/utils": "6.5.3"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/graphics-smooth": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics-smooth/-/graphics-smooth-0.0.22.tgz",
-      "integrity": "sha512-qq2u+BJBIDBuuSTc2Xzm1D/8RiiKBdxnVDiMb7Go5v8achnV5ctC6m+rf8Mq0sWm66mbOqu1aq/9efT4A4sPrA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14",
-        "npm": ">=7"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "^6.0.4",
-        "@pixi/core": "^6.0.4",
-        "@pixi/display": "^6.0.4",
-        "@pixi/graphics": "^6.0.4",
-        "@pixi/math": "^6.0.4",
-        "@pixi/utils": "^6.0.4"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/math": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.3.tgz",
-      "integrity": "sha512-0BK/9PB/9vqAln8VBAYJHVOZdugU3JW139rwUWqgzpgcPTRVbKlaQR85Jg3RkvB0rYukxurdX4/mLQTfOmdRVg==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/runner": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.3.tgz",
-      "integrity": "sha512-yUFKlu6m4525lRY9VqVOftQOeJAzCfpHH4k3O1LszmJyQy71QoKQhcnsMLvld7+sf0smw7s4uFpF5xeF0UPTwA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/settings": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.3.tgz",
-      "integrity": "sha512-3T2WCjO37kLuAFDLkfumtWjQMETChANRB2u5cYpCqwss8cO/QiGLW25/tNx12GuI6p6QiGx/SjsT4OoNHiPSgg==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/sprite": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.3.tgz",
-      "integrity": "sha512-ly/OBTwpuoPpk9w9xSOsJ0/dM4pu2MdghVzqDYjsODqSq9eibCsFwpOnPLhtTV8letoODc0V9XJKqog2vr03Ag==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.3",
-        "@pixi/core": "6.5.3",
-        "@pixi/display": "6.5.3",
-        "@pixi/math": "6.5.3",
-        "@pixi/settings": "6.5.3",
-        "@pixi/utils": "6.5.3"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/ticker": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.3.tgz",
-      "integrity": "sha512-4RHoPxCdH8017HaY+l/F6xTS8igNja5sEQtyXSWlPvd1Y3jnifmIvzi8nrpn7JIHpeN7iHenRCjyM3UYEyUr7g==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/extensions": "6.5.3",
-        "@pixi/settings": "6.5.3"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types/node_modules/@pixi/utils": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.3.tgz",
-      "integrity": "sha512-zucVQSByYoJeKAfVaYMDvF9ku8y79aUhnHDWEUt1lNNi5hbnMzIGxKkB2R/IPct5ASulQmJBvW9t/MS/UKVc2Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
-        "eventemitter3": "^3.1.0",
-        "url": "^0.11.0"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.5.3",
-        "@pixi/settings": "6.5.3"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -301,394 +145,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pixi/accessibility": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.11.tgz",
-      "integrity": "sha512-/oSizd8/g6KUCeAlknMLJ9CRxBt+vWs6e2DrOctMoRupEHcmhICCjIyAp5GF6RZy9T9gNHDOU5p7vo7qEyVxgQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/app": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.11.tgz",
-      "integrity": "sha512-ZWrOjGvVl+lK5OJQT3OqSnSRtU2XgQSe/ULg2uGsSWUqMkJews33JIGOjvk4tIsjm4ekSKiPZRMdYFHzPfgEJg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/constants": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
-      "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
-      "dev": true
-    },
-    "node_modules/@pixi/core": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
-      "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/runner": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/ticker": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
-    "node_modules/@pixi/display": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
-      "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/extensions": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.3.tgz",
-      "integrity": "sha512-5I9wKGMGIy/Nnm+SX4k70i4LkSo/jFNPyMixNYzJyX+gEoLiQawyJ0qD9WJHDCPtwMaBV8d2OzXxZT5wdbIx2w==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@pixi/extract": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.11.tgz",
-      "integrity": "sha512-YeBrpIO3E5HUgcdKEldCUqwwDNHm5OBe98YFcdLr5Z0+dQaHnxp9Dm4n75/NojoGb5guYdrV00x+gU2UPHsVdw==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/filter-alpha": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.11.tgz",
-      "integrity": "sha512-HC4PbiEqDWSi3A715av7knFqD3knSXRxPJKG9mWat2CU9eCizSw+JxXp/okMU/fL4ewooiqQWVU2l1wXOHhVFw==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/filter-blur": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.11.tgz",
-      "integrity": "sha512-iW5cOMEcDiJidOV95bUfhxdcvwM9JzCoWAd+92gAie8L+ElRSHpu1jxXbKHjo/QczQV1LulOlheyDaJNpaBCDg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/settings": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/filter-color-matrix": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.11.tgz",
-      "integrity": "sha512-u9NT4+N1I3XV9ygwsmF8/jIwCLqNCLeFOdM4f73kbw/UmakZZ6i6xjjJMc5YFUpC25qDr1TFlqgdGGGHAPl4ug==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/filter-displacement": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.11.tgz",
-      "integrity": "sha512-CTIy7C/L9I1X3VNx4nMzQbMFvznsGk2viQh0dSo8r5NLgmaAdxhkGI0KUpNjLBz30278tzFfNuRe59K1y1kHuw==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/filter-fxaa": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.11.tgz",
-      "integrity": "sha512-0ahjui5385e1vRvd7zCc0n5W8ULtNI1uVbDJHP9ueeiF25TKC0GqtZzntNwrQPoU46q8zXdnIGjzMpikbbAasg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/filter-noise": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.11.tgz",
-      "integrity": "sha512-98WC9Nd5u2F03Ned9T3vnbmO/YF1jLSioZ623z9wjqpd5DosZgRtYTSGxjVcXTSfpviIuiJpkyF+X097pbVprg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/graphics": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
-      "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/interaction": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.11.tgz",
-      "integrity": "sha512-n2K99CYyBcrf8NPxpzmZ5IlJ9TEplsSZfJ/uzMNOEnTObKl4wAhxs51Nb58raH3Ouzwu14YHOpqYrBTEoT1yPA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/ticker": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/loaders": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.11.tgz",
-      "integrity": "sha512-1HAeb/NFXyhNhZWAbVkngsTPBGpjZEPhQflBTrKycRaub7XDSZ8F0fwPltpKKVRWNDT+HBgU/zDNE2fpjzqfYg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/utils": "5.3.11",
-        "resource-loader": "^3.0.1"
-      }
-    },
-    "node_modules/@pixi/math": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
-      "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
-      "dev": true
-    },
-    "node_modules/@pixi/mesh": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.11.tgz",
-      "integrity": "sha512-KWKKksEr0YuUX1uz1FmpIa/Y37b/0pvFUS+87LoyYq0mRtGbKsTY5i3lBPG/taHwN7a2DQAX3JZpw6yhGKoGpA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/mesh-extras": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.11.tgz",
-      "integrity": "sha512-1GTCMMUW1xv/72x26cxRysblBXW0wU77TNgqtSIMZ1M6JbleObChklWTvwi9MzQO2vQ3S6Hvcsa5m5EiM2hSPQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/mesh": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.11.tgz",
-      "integrity": "sha512-uQUxatGTTD5zfQ0pWdjibVjT+xEEZJ/xZDZtm/GxC7HSHd4jgoJBcTXWVhbhzwpLPVTnD8+sMnRrGlhoKcpTpQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.11.tgz",
-      "integrity": "sha512-fWFVxWtMYcwJttrgDNmZ4CJrx316p8ToNliC2ILmJZW77me7I4GzJ57gSHQU1xFwdHoOYRC4fnlrZoK5qJ9lDw==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/display": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/mixin-get-global-position": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.11.tgz",
-      "integrity": "sha512-wrS9i+UUodLM5XL2N0Y+XSKiqLRdJV3ltFUWG6+jPT5yoP0HsKtx3sFAzX526RwIYwRzRusbc/quxHfRA4tvgg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/particles": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.11.tgz",
-      "integrity": "sha512-+mkt/inWXtRrxQc07RZ29uNIDWV1oMsrRBVBIvHgpR92Kn8EjIDRgoSXNu0jiZ18gRKKCBhwsS4dCXGsZRQ/sA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/polyfill": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.11.tgz",
-      "integrity": "sha512-yQOngcnn+2/L7n6L/g45hCnIDLWdnWmmcCY3UKJrOgbNX+JtLru1RR8AGLifkdsa0R5u48x584YQGqkTAChWVA==",
-      "dev": true,
-      "dependencies": {
-        "es6-promise-polyfill": "^1.2.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/@pixi/prepare": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.11.tgz",
-      "integrity": "sha512-TvjGeg7xPKjv5NxbM5NXReno9yxUCw/N0HtDEtEFRVeBLN3u0Q/dZsXxL6gIvkHoS09NFW+7AwsYQLZrVbppjA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/graphics": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/text": "5.3.11",
-        "@pixi/ticker": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/runner": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
-      "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
-      "dev": true
-    },
-    "node_modules/@pixi/settings": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
-      "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
-      "dev": true,
-      "dependencies": {
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "node_modules/@pixi/sprite": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
-      "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/sprite-animated": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.11.tgz",
-      "integrity": "sha512-xU1b6H8nJ1l05h7cBGw2DGo4QdLj7xootstZUx2BrTVX5ZENn5mjAGVD0uRpk8yt7Q6Bj7M+PS7ktzAgBW/hmQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/ticker": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/sprite-tiling": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.11.tgz",
-      "integrity": "sha512-KUiWsIumjrnp9QKGMe1BqtrV9Hxm91KoaiOlCBk/gw8753iKvuMmH+/Z0RnzeZylJ1sJsdonTWy/IaLi1jnd0g==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/spritesheet": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.11.tgz",
-      "integrity": "sha512-Y9Wiwcz/YOuS1v73Ij9KWQakYBzZfldEy3H8T4GPLK+S19/sypntdkNtRZbmR2wWfhJ4axYEB2/Df86aOAU2qA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/loaders": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/text": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.11.tgz",
-      "integrity": "sha512-PmWvJv0wiKyyz3fahnxM19+m8IbF2vpDKIImqb5472WyxRGzKyVBW90xrADf5202tdKMk4b8hqvpof2XULr5PA==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/text-bitmap": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.11.tgz",
-      "integrity": "sha512-Bjc/G4VHaPXc9HJsvyYOm5cNTHdqmX6AgzBAlCfltuMAlnveUgUPuX8D/MJHRRnoVSDHSmCBtnJgTc0y/nIeCw==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/loaders": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/mesh": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/text": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/ticker": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
-      "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/settings": "5.3.11"
-      }
-    },
-    "node_modules/@pixi/utils": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
-      "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "earcut": "^2.1.5",
-        "eventemitter3": "^3.1.0",
-        "url": "^0.11.0"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -728,28 +184,6 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
-    "node_modules/@socket.io/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
-      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
-      "dev": true
-    },
-    "node_modules/@types/earcut": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
-      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -775,15 +209,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/jquery": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
-      "dev": true,
-      "dependencies": {
-        "@types/sizzle": "*"
-      }
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -796,13 +221,6 @@
       "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
-      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -811,21 +229,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/simple-peer": {
-      "version": "9.11.4",
-      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.4.tgz",
-      "integrity": "sha512-Elje14YvM47k+XEaoyRAeUSvZN7TOLWYL233QCckUaXjT4lRESHnYs0iOK2JoosO5DnCvWu/0Vpl9qnw4KCLWw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.7.0",
@@ -859,12 +262,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -959,23 +356,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -997,47 +377,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "dev": true
-    },
-    "node_modules/engine.io-client": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.0.3.tgz",
-      "integrity": "sha512-IH8ZhDIwiLv0d/wXVzmjfV9Y82hbJIDhCGSVUV8o1kcpDe2I6Y3bZA3ZbJy4Ls7k7IVmcy/qn4k9RKWFhUGf5w==",
-      "dev": true,
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.0",
-        "has-cors": "1.1.0",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "ws": "~8.2.3",
-        "xmlhttprequest-ssl": "~2.0.0",
-        "yeast": "0.1.2"
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
-      "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
-      "dev": true,
-      "dependencies": {
-        "@socket.io/base64-arraybuffer": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/es6-promise-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
-      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4=",
-      "dev": true
-    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1051,12 +390,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
-    },
-    "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -1192,27 +525,6 @@
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1224,12 +536,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-      "dev": true
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -1322,12 +628,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ismobilejs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "dev": true
-    },
     "node_modules/jest-worker": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
@@ -1406,12 +706,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mini-signals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=",
-      "dev": true
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1424,33 +718,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1459,27 +726,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/parse-uri": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
-      "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/parseqs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-      "dev": true
-    },
-    "node_modules/parseuri": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-      "dev": true
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -1517,61 +763,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pixi-particles": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/pixi-particles/-/pixi-particles-4.3.1.tgz",
-      "integrity": "sha512-XSqDFgYwm/7FRCgP5I2Fc57d98qvb1ql/x4uTjdP4uXDUGgjdO8OW/2A0HVWS1CkOht/1x6dQzsM1oCJAUlaow==",
-      "dev": true,
-      "peerDependencies": {
-        "pixi.js": ">=4.0.0"
-      }
-    },
-    "node_modules/pixi.js": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.11.tgz",
-      "integrity": "sha512-/9td6IHDQqG0Po5lyQ5aKDzrnEVD1SvGourI4Nqp0mvNI0Cbm74tMHLjk1V5foqGPAS9pochENr6Y3ft/2cDiQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/accessibility": "5.3.11",
-        "@pixi/app": "5.3.11",
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/extract": "5.3.11",
-        "@pixi/filter-alpha": "5.3.11",
-        "@pixi/filter-blur": "5.3.11",
-        "@pixi/filter-color-matrix": "5.3.11",
-        "@pixi/filter-displacement": "5.3.11",
-        "@pixi/filter-fxaa": "5.3.11",
-        "@pixi/filter-noise": "5.3.11",
-        "@pixi/graphics": "5.3.11",
-        "@pixi/interaction": "5.3.11",
-        "@pixi/loaders": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/mesh": "5.3.11",
-        "@pixi/mesh-extras": "5.3.11",
-        "@pixi/mixin-cache-as-bitmap": "5.3.11",
-        "@pixi/mixin-get-child-by-name": "5.3.11",
-        "@pixi/mixin-get-global-position": "5.3.11",
-        "@pixi/particles": "5.3.11",
-        "@pixi/polyfill": "5.3.11",
-        "@pixi/prepare": "5.3.11",
-        "@pixi/runner": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/sprite-animated": "5.3.11",
-        "@pixi/sprite-tiling": "5.3.11",
-        "@pixi/spritesheet": "5.3.11",
-        "@pixi/text": "5.3.11",
-        "@pixi/text-bitmap": "5.3.11",
-        "@pixi/ticker": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
-      }
-    },
     "node_modules/prettier": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
@@ -1585,22 +776,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
@@ -1647,16 +822,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resource-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
-      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
-      "dev": true,
-      "dependencies": {
-        "mini-signals": "^1.2.0",
-        "parse-uri": "^1.0.0"
       }
     },
     "node_modules/reusify": {
@@ -1776,36 +941,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/socket.io-client": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.3.2.tgz",
-      "integrity": "sha512-2B9LqSunN60yV8F7S84CCEEcgbYNfrn7ejIInZtLZ7ppWtiX8rGZAjvdCvbnC8bqo/9RlCNOUsORLyskxSFP1g==",
-      "dev": true,
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "backo2": "~1.0.2",
-        "debug": "~4.3.2",
-        "engine.io-client": "~6.0.1",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~4.1.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
-      "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
-      "dev": true,
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "debug": "~4.3.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1867,12 +1002,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tinymce": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.1.tgz",
-      "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
-      "dev": true
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1885,19 +1014,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/uglify-js": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -1907,62 +1023,10 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xmlhttprequest-ssl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     }
   },
@@ -2042,114 +1106,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@league-of-foundry-developers/foundry-vtt-types": {
-      "version": "9.280.0",
-      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-9.280.0.tgz",
-      "integrity": "sha512-Dv8/+kgAnI2F5snSWcnMnZsgO/87AFyBruflluZkWDbP7Pm5qi32GlNYCDEg7HMKybzyKmgLV2qXMmYPHtCT7w==",
-      "dev": true,
-      "requires": {
-        "@pixi/graphics-smooth": "0.0.22",
-        "@types/jquery": "~3.5.9",
-        "@types/simple-peer": "~9.11.1",
-        "handlebars": "4.7.7",
-        "pixi-particles": "4.3.1",
-        "pixi.js": "5.3.11",
-        "socket.io-client": "4.3.2",
-        "tinymce": "5.10.1"
-      },
-      "dependencies": {
-        "@pixi/constants": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.3.tgz",
-          "integrity": "sha512-h/0Sf6ak0f0bLKo87CQDAUi9+VbAerJi8uKsq4d1DyXYGCNizjIiBVBUfWAPmzJ7JQ79hMn3fYXWCzlp4flKfw==",
-          "dev": true,
-          "peer": true
-        },
-        "@pixi/core": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.3.tgz",
-          "integrity": "sha512-537nYn5RmXrjSiaDUa5O6Rg72JifoAuKDw2YtAlg9LvoY8jKo2ZP3NvIqrMo2GIjD/I2mznGcU+s9VPzP8lBCQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@types/offscreencanvas": "^2019.6.4"
-          }
-        },
-        "@pixi/display": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.3.tgz",
-          "integrity": "sha512-Oq51rmnaqbv08z+CuSi75GPKyrzrDi96A1J7mNMJMq4CV6zrwSzCrjo6fcK1Fa47fHRbnkvOqhMQ5aR6NV09MA==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        },
-        "@pixi/graphics": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.3.tgz",
-          "integrity": "sha512-jALPefMEadpW4A/ryf3ALo+a8RY3vPcSUAuSu+W60zBhWcLas5O7doNmdwkBNSp06sYalvdl64xs1oBwaoxWQg==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        },
-        "@pixi/graphics-smooth": {
-          "version": "0.0.22",
-          "resolved": "https://registry.npmjs.org/@pixi/graphics-smooth/-/graphics-smooth-0.0.22.tgz",
-          "integrity": "sha512-qq2u+BJBIDBuuSTc2Xzm1D/8RiiKBdxnVDiMb7Go5v8achnV5ctC6m+rf8Mq0sWm66mbOqu1aq/9efT4A4sPrA==",
-          "dev": true,
-          "requires": {}
-        },
-        "@pixi/math": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.3.tgz",
-          "integrity": "sha512-0BK/9PB/9vqAln8VBAYJHVOZdugU3JW139rwUWqgzpgcPTRVbKlaQR85Jg3RkvB0rYukxurdX4/mLQTfOmdRVg==",
-          "dev": true,
-          "peer": true
-        },
-        "@pixi/runner": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.3.tgz",
-          "integrity": "sha512-yUFKlu6m4525lRY9VqVOftQOeJAzCfpHH4k3O1LszmJyQy71QoKQhcnsMLvld7+sf0smw7s4uFpF5xeF0UPTwA==",
-          "dev": true,
-          "peer": true
-        },
-        "@pixi/settings": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.3.tgz",
-          "integrity": "sha512-3T2WCjO37kLuAFDLkfumtWjQMETChANRB2u5cYpCqwss8cO/QiGLW25/tNx12GuI6p6QiGx/SjsT4OoNHiPSgg==",
-          "dev": true,
-          "peer": true
-        },
-        "@pixi/sprite": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.3.tgz",
-          "integrity": "sha512-ly/OBTwpuoPpk9w9xSOsJ0/dM4pu2MdghVzqDYjsODqSq9eibCsFwpOnPLhtTV8letoODc0V9XJKqog2vr03Ag==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        },
-        "@pixi/ticker": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.3.tgz",
-          "integrity": "sha512-4RHoPxCdH8017HaY+l/F6xTS8igNja5sEQtyXSWlPvd1Y3jnifmIvzi8nrpn7JIHpeN7iHenRCjyM3UYEyUr7g==",
-          "dev": true,
-          "peer": true,
-          "requires": {}
-        },
-        "@pixi/utils": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.3.tgz",
-          "integrity": "sha512-zucVQSByYoJeKAfVaYMDvF9ku8y79aUhnHDWEUt1lNNi5hbnMzIGxKkB2R/IPct5ASulQmJBvW9t/MS/UKVc2Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@types/earcut": "^2.1.0",
-            "earcut": "^2.2.4",
-            "eventemitter3": "^3.1.0",
-            "url": "^0.11.0"
-          }
-        }
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2174,390 +1130,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
-      }
-    },
-    "@pixi/accessibility": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.3.11.tgz",
-      "integrity": "sha512-/oSizd8/g6KUCeAlknMLJ9CRxBt+vWs6e2DrOctMoRupEHcmhICCjIyAp5GF6RZy9T9gNHDOU5p7vo7qEyVxgQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/app": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.3.11.tgz",
-      "integrity": "sha512-ZWrOjGvVl+lK5OJQT3OqSnSRtU2XgQSe/ULg2uGsSWUqMkJews33JIGOjvk4tIsjm4ekSKiPZRMdYFHzPfgEJg==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11"
-      }
-    },
-    "@pixi/constants": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.3.11.tgz",
-      "integrity": "sha512-KwutCRu8dRYn3956ygPJlvglHjJM99OS2Qhp4QYG8a4BsPcwfpInsHUtGHngtsTZbnx32pxCd3pg9nPiV8EuVA==",
-      "dev": true
-    },
-    "@pixi/core": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.3.11.tgz",
-      "integrity": "sha512-U71OiC3rNt45/h8kaLGAQL4XsNh/ISoZtxVQNbtKTXlgjEAy1Q01Ht80yl0UJdiVxYQFlanCS/IG4++OkygioA==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/runner": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/ticker": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/display": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.3.11.tgz",
-      "integrity": "sha512-rxUyB+RMJ7esEa11HdvzsularDGkYlRqpUn1ju9ZsRuB/Qo9JiVolywvWGSWxN/WnDGfrU2GjDpq9id10nwiag==",
-      "dev": true,
-      "requires": {
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/extensions": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.3.tgz",
-      "integrity": "sha512-5I9wKGMGIy/Nnm+SX4k70i4LkSo/jFNPyMixNYzJyX+gEoLiQawyJ0qD9WJHDCPtwMaBV8d2OzXxZT5wdbIx2w==",
-      "dev": true,
-      "peer": true
-    },
-    "@pixi/extract": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.3.11.tgz",
-      "integrity": "sha512-YeBrpIO3E5HUgcdKEldCUqwwDNHm5OBe98YFcdLr5Z0+dQaHnxp9Dm4n75/NojoGb5guYdrV00x+gU2UPHsVdw==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/filter-alpha": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.3.11.tgz",
-      "integrity": "sha512-HC4PbiEqDWSi3A715av7knFqD3knSXRxPJKG9mWat2CU9eCizSw+JxXp/okMU/fL4ewooiqQWVU2l1wXOHhVFw==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "@pixi/filter-blur": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.3.11.tgz",
-      "integrity": "sha512-iW5cOMEcDiJidOV95bUfhxdcvwM9JzCoWAd+92gAie8L+ElRSHpu1jxXbKHjo/QczQV1LulOlheyDaJNpaBCDg==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/settings": "5.3.11"
-      }
-    },
-    "@pixi/filter-color-matrix": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.11.tgz",
-      "integrity": "sha512-u9NT4+N1I3XV9ygwsmF8/jIwCLqNCLeFOdM4f73kbw/UmakZZ6i6xjjJMc5YFUpC25qDr1TFlqgdGGGHAPl4ug==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "@pixi/filter-displacement": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.3.11.tgz",
-      "integrity": "sha512-CTIy7C/L9I1X3VNx4nMzQbMFvznsGk2viQh0dSo8r5NLgmaAdxhkGI0KUpNjLBz30278tzFfNuRe59K1y1kHuw==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11"
-      }
-    },
-    "@pixi/filter-fxaa": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.3.11.tgz",
-      "integrity": "sha512-0ahjui5385e1vRvd7zCc0n5W8ULtNI1uVbDJHP9ueeiF25TKC0GqtZzntNwrQPoU46q8zXdnIGjzMpikbbAasg==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "@pixi/filter-noise": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.3.11.tgz",
-      "integrity": "sha512-98WC9Nd5u2F03Ned9T3vnbmO/YF1jLSioZ623z9wjqpd5DosZgRtYTSGxjVcXTSfpviIuiJpkyF+X097pbVprg==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11"
-      }
-    },
-    "@pixi/graphics": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.3.11.tgz",
-      "integrity": "sha512-HLu53LV6mRlY0uFSIM2OrCuL7xqXzeJs5d2QfmUJfKJVVZ9sbHDS+6/N/f0tXzvkRPYhSKXvcNPsNn4HmlIE9w==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/interaction": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.3.11.tgz",
-      "integrity": "sha512-n2K99CYyBcrf8NPxpzmZ5IlJ9TEplsSZfJ/uzMNOEnTObKl4wAhxs51Nb58raH3Ouzwu14YHOpqYrBTEoT1yPA==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/ticker": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/loaders": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.3.11.tgz",
-      "integrity": "sha512-1HAeb/NFXyhNhZWAbVkngsTPBGpjZEPhQflBTrKycRaub7XDSZ8F0fwPltpKKVRWNDT+HBgU/zDNE2fpjzqfYg==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/utils": "5.3.11",
-        "resource-loader": "^3.0.1"
-      }
-    },
-    "@pixi/math": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.3.11.tgz",
-      "integrity": "sha512-GAupgFWVuOKxh8A322x8IctNgKi0/pLTJAXxmsLxcUw5PIQGgDw894HvzUriI+C0fsa9cEZHUbOCfyBKPQDLzw==",
-      "dev": true
-    },
-    "@pixi/mesh": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.3.11.tgz",
-      "integrity": "sha512-KWKKksEr0YuUX1uz1FmpIa/Y37b/0pvFUS+87LoyYq0mRtGbKsTY5i3lBPG/taHwN7a2DQAX3JZpw6yhGKoGpA==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/mesh-extras": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.3.11.tgz",
-      "integrity": "sha512-1GTCMMUW1xv/72x26cxRysblBXW0wU77TNgqtSIMZ1M6JbleObChklWTvwi9MzQO2vQ3S6Hvcsa5m5EiM2hSPQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/mesh": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/mixin-cache-as-bitmap": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.11.tgz",
-      "integrity": "sha512-uQUxatGTTD5zfQ0pWdjibVjT+xEEZJ/xZDZtm/GxC7HSHd4jgoJBcTXWVhbhzwpLPVTnD8+sMnRrGlhoKcpTpQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/mixin-get-child-by-name": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.11.tgz",
-      "integrity": "sha512-fWFVxWtMYcwJttrgDNmZ4CJrx316p8ToNliC2ILmJZW77me7I4GzJ57gSHQU1xFwdHoOYRC4fnlrZoK5qJ9lDw==",
-      "dev": true,
-      "requires": {
-        "@pixi/display": "5.3.11"
-      }
-    },
-    "@pixi/mixin-get-global-position": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.11.tgz",
-      "integrity": "sha512-wrS9i+UUodLM5XL2N0Y+XSKiqLRdJV3ltFUWG6+jPT5yoP0HsKtx3sFAzX526RwIYwRzRusbc/quxHfRA4tvgg==",
-      "dev": true,
-      "requires": {
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11"
-      }
-    },
-    "@pixi/particles": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.3.11.tgz",
-      "integrity": "sha512-+mkt/inWXtRrxQc07RZ29uNIDWV1oMsrRBVBIvHgpR92Kn8EjIDRgoSXNu0jiZ18gRKKCBhwsS4dCXGsZRQ/sA==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/polyfill": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.3.11.tgz",
-      "integrity": "sha512-yQOngcnn+2/L7n6L/g45hCnIDLWdnWmmcCY3UKJrOgbNX+JtLru1RR8AGLifkdsa0R5u48x584YQGqkTAChWVA==",
-      "dev": true,
-      "requires": {
-        "es6-promise-polyfill": "^1.2.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "@pixi/prepare": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.3.11.tgz",
-      "integrity": "sha512-TvjGeg7xPKjv5NxbM5NXReno9yxUCw/N0HtDEtEFRVeBLN3u0Q/dZsXxL6gIvkHoS09NFW+7AwsYQLZrVbppjA==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/graphics": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/text": "5.3.11",
-        "@pixi/ticker": "5.3.11"
-      }
-    },
-    "@pixi/runner": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.3.11.tgz",
-      "integrity": "sha512-Mtb0rnSG+6KOIbr/48AtrILr8PZQepYwqYixVEXM6UHl+7+Z5NIx9fOByiicdjEKJvHIAYveu8yp2/L1vkF+qw==",
-      "dev": true
-    },
-    "@pixi/settings": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.3.11.tgz",
-      "integrity": "sha512-ny/rjSmP+64WqxwmoY17KsFplxpuWbiMQ5SNAgkpi36z6k+utIGT05nIIhyMx3AAGSY+6dRbKmLeKyqCj8q4zw==",
-      "dev": true,
-      "requires": {
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "@pixi/sprite": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.3.11.tgz",
-      "integrity": "sha512-RM6Sp8kqzsBdX/hDAO25HZywe9VU4uhOronUOQ5Ve0zRe+trdBWQYfi7+5kAcvzqkp25Izc0C+e+4YCqe5OaHQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/sprite-animated": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.3.11.tgz",
-      "integrity": "sha512-xU1b6H8nJ1l05h7cBGw2DGo4QdLj7xootstZUx2BrTVX5ZENn5mjAGVD0uRpk8yt7Q6Bj7M+PS7ktzAgBW/hmQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/ticker": "5.3.11"
-      }
-    },
-    "@pixi/sprite-tiling": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.3.11.tgz",
-      "integrity": "sha512-KUiWsIumjrnp9QKGMe1BqtrV9Hxm91KoaiOlCBk/gw8753iKvuMmH+/Z0RnzeZylJ1sJsdonTWy/IaLi1jnd0g==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/spritesheet": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.3.11.tgz",
-      "integrity": "sha512-Y9Wiwcz/YOuS1v73Ij9KWQakYBzZfldEy3H8T4GPLK+S19/sypntdkNtRZbmR2wWfhJ4axYEB2/Df86aOAU2qA==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/loaders": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/text": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.3.11.tgz",
-      "integrity": "sha512-PmWvJv0wiKyyz3fahnxM19+m8IbF2vpDKIImqb5472WyxRGzKyVBW90xrADf5202tdKMk4b8hqvpof2XULr5PA==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/text-bitmap": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.3.11.tgz",
-      "integrity": "sha512-Bjc/G4VHaPXc9HJsvyYOm5cNTHdqmX6AgzBAlCfltuMAlnveUgUPuX8D/MJHRRnoVSDHSmCBtnJgTc0y/nIeCw==",
-      "dev": true,
-      "requires": {
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/loaders": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/mesh": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/text": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
-    "@pixi/ticker": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.3.11.tgz",
-      "integrity": "sha512-J1CChbSo1SQib1zL5f+FcFJZ6wN7LnWpztJVpKKYy3ZM/v4HSh48UnrGDKn5SLwSq4K7BxvZduwMQ8m4Paz1gQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/settings": "5.3.11"
-      }
-    },
-    "@pixi/utils": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.3.11.tgz",
-      "integrity": "sha512-25ZSCTrfV8da28IzvLnTK0BGWB4dHpq5P9IEgFymJvVLK7sAyT+RPz18ewRbBHgALHsszDpfC+qrHp3i+VZP0Q==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "earcut": "^2.1.5",
-        "eventemitter3": "^3.1.0",
-        "url": "^0.11.0"
       }
     },
     "@rollup/plugin-node-resolve": {
@@ -2585,25 +1157,6 @@
         "picomatch": "^2.2.2"
       }
     },
-    "@socket.io/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-dOlCBKnDw4iShaIsH/bxujKTM18+2TOAsYz+KSc11Am38H4q5Xw8Bbz97ZYdrVNM+um3p7w86Bvvmcn9q+5+eQ==",
-      "dev": true
-    },
-    "@socket.io/component-emitter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
-      "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
-      "dev": true
-    },
-    "@types/earcut": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
-      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
-      "dev": true,
-      "peer": true
-    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -2629,15 +1182,6 @@
         "@types/node": "*"
       }
     },
-    "@types/jquery": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
-      "dev": true,
-      "requires": {
-        "@types/sizzle": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2650,13 +1194,6 @@
       "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
-    "@types/offscreencanvas": {
-      "version": "2019.7.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
-      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
-      "dev": true,
-      "peer": true
-    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -2665,21 +1202,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/simple-peer": {
-      "version": "9.11.4",
-      "resolved": "https://registry.npmjs.org/@types/simple-peer/-/simple-peer-9.11.4.tgz",
-      "integrity": "sha512-Elje14YvM47k+XEaoyRAeUSvZN7TOLWYL233QCckUaXjT4lRESHnYs0iOK2JoosO5DnCvWu/0Vpl9qnw4KCLWw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
     },
     "acorn": {
       "version": "8.7.0",
@@ -2700,12 +1222,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
-    },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
@@ -2789,15 +1305,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -2813,44 +1320,6 @@
         "path-type": "^4.0.0"
       }
     },
-    "earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "dev": true
-    },
-    "engine.io-client": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.0.3.tgz",
-      "integrity": "sha512-IH8ZhDIwiLv0d/wXVzmjfV9Y82hbJIDhCGSVUV8o1kcpDe2I6Y3bZA3ZbJy4Ls7k7IVmcy/qn4k9RKWFhUGf5w==",
-      "dev": true,
-      "requires": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.0",
-        "has-cors": "1.1.0",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "ws": "~8.2.3",
-        "xmlhttprequest-ssl": "~2.0.0",
-        "yeast": "0.1.2"
-      }
-    },
-    "engine.io-parser": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.3.tgz",
-      "integrity": "sha512-BtQxwF27XUNnSafQLvDi0dQ8s3i6VgzSoQMJacpIcGNrlUdfHSKbgm3jmjCVvQluGzqwujQMPAoMai3oYSTurg==",
-      "dev": true,
-      "requires": {
-        "@socket.io/base64-arraybuffer": "~1.0.2"
-      }
-    },
-    "es6-promise-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
-      "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4=",
-      "dev": true
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2861,12 +1330,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "dev": true
     },
     "fast-glob": {
@@ -2974,19 +1437,6 @@
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2995,12 +1445,6 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -3072,12 +1516,6 @@
       "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
       "dev": true
     },
-    "ismobilejs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "dev": true
-    },
     "jest-worker": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
@@ -3143,12 +1581,6 @@
         "picomatch": "^2.3.1"
       }
     },
-    "mini-signals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3158,30 +1590,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3190,24 +1598,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "parse-uri": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.7.tgz",
-      "integrity": "sha512-eWuZCMKNlVkXrEoANdXxbmqhu2SQO9jUMCSpdbJDObin0JxISn6e400EWsSRbr/czdKvWKkhZnMKEGUwf/Plmg==",
-      "dev": true
-    },
-    "parseqs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-      "dev": true
-    },
-    "parseuri": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3233,71 +1623,10 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
-    "pixi-particles": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/pixi-particles/-/pixi-particles-4.3.1.tgz",
-      "integrity": "sha512-XSqDFgYwm/7FRCgP5I2Fc57d98qvb1ql/x4uTjdP4uXDUGgjdO8OW/2A0HVWS1CkOht/1x6dQzsM1oCJAUlaow==",
-      "dev": true,
-      "requires": {}
-    },
-    "pixi.js": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.3.11.tgz",
-      "integrity": "sha512-/9td6IHDQqG0Po5lyQ5aKDzrnEVD1SvGourI4Nqp0mvNI0Cbm74tMHLjk1V5foqGPAS9pochENr6Y3ft/2cDiQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/accessibility": "5.3.11",
-        "@pixi/app": "5.3.11",
-        "@pixi/constants": "5.3.11",
-        "@pixi/core": "5.3.11",
-        "@pixi/display": "5.3.11",
-        "@pixi/extract": "5.3.11",
-        "@pixi/filter-alpha": "5.3.11",
-        "@pixi/filter-blur": "5.3.11",
-        "@pixi/filter-color-matrix": "5.3.11",
-        "@pixi/filter-displacement": "5.3.11",
-        "@pixi/filter-fxaa": "5.3.11",
-        "@pixi/filter-noise": "5.3.11",
-        "@pixi/graphics": "5.3.11",
-        "@pixi/interaction": "5.3.11",
-        "@pixi/loaders": "5.3.11",
-        "@pixi/math": "5.3.11",
-        "@pixi/mesh": "5.3.11",
-        "@pixi/mesh-extras": "5.3.11",
-        "@pixi/mixin-cache-as-bitmap": "5.3.11",
-        "@pixi/mixin-get-child-by-name": "5.3.11",
-        "@pixi/mixin-get-global-position": "5.3.11",
-        "@pixi/particles": "5.3.11",
-        "@pixi/polyfill": "5.3.11",
-        "@pixi/prepare": "5.3.11",
-        "@pixi/runner": "5.3.11",
-        "@pixi/settings": "5.3.11",
-        "@pixi/sprite": "5.3.11",
-        "@pixi/sprite-animated": "5.3.11",
-        "@pixi/sprite-tiling": "5.3.11",
-        "@pixi/spritesheet": "5.3.11",
-        "@pixi/text": "5.3.11",
-        "@pixi/text-bitmap": "5.3.11",
-        "@pixi/ticker": "5.3.11",
-        "@pixi/utils": "5.3.11"
-      }
-    },
     "prettier": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
       "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
-      "dev": true
-    },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-      "dev": true
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "queue-microtask": {
@@ -3324,16 +1653,6 @@
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "resource-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
-      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
-      "dev": true,
-      "requires": {
-        "mini-signals": "^1.2.0",
-        "parse-uri": "^1.0.0"
       }
     },
     "reusify": {
@@ -3406,30 +1725,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "socket.io-client": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.3.2.tgz",
-      "integrity": "sha512-2B9LqSunN60yV8F7S84CCEEcgbYNfrn7ejIInZtLZ7ppWtiX8rGZAjvdCvbnC8bqo/9RlCNOUsORLyskxSFP1g==",
-      "dev": true,
-      "requires": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "backo2": "~1.0.2",
-        "debug": "~4.3.2",
-        "engine.io-client": "~6.0.1",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~4.1.1"
-      }
-    },
-    "socket.io-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
-      "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
-      "dev": true,
-      "requires": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "debug": "~4.3.1"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3473,12 +1768,6 @@
         "source-map-support": "~0.5.20"
       }
     },
-    "tinymce": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.1.tgz",
-      "integrity": "sha512-aIsFTYiuESpoYkCgkoojpVtPwrSvYBxp4mMEGsj20CnUruLCWosywkbYHDII+j7KlQZZn3p+xK89f5gT3QyuGw==",
-      "dev": true
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3488,58 +1777,16 @@
         "is-number": "^7.0.0"
       }
     },
-    "uglify-js": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
-      "dev": true,
-      "optional": true
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true,
-      "requires": {}
-    },
-    "xmlhttprequest-ssl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-      "dev": true
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.6",
   "description": "Hex Size Support",
   "devDependencies": {
-    "@league-of-foundry-developers/foundry-vtt-types": "^9.280.0",
     "@rollup/plugin-node-resolve": "^13.0.5",
     "prettier": "^2.4.1",
     "rollup": "^2.58.0",

--- a/public/module.json
+++ b/public/module.json
@@ -14,10 +14,10 @@
 			"url": "https://github.com/Ourobor"
 		}
 	],
-	"version": "1.3.0",
+	"version": "3.0.0",
 	"compatibility": {
-		"minimum": "10",
-		"verified": "10"
+		"minimum": "11",
+		"verified": "11"
 	},
 	"relationships": {
 		"requires": [
@@ -26,7 +26,7 @@
 				"type": "module",
 				"compatibility": {
 					"minimum": "1.0.0.0",
-					"verified": "1.12.6.0"
+					"verified": "1.12.13.0"
 				}
 			}
 		]

--- a/public/module.json
+++ b/public/module.json
@@ -17,7 +17,8 @@
 	"version": "3.0.0",
 	"compatibility": {
 		"minimum": "11",
-		"verified": "11"
+		"verified": "11",
+		"maximum": "11"
 	},
 	"relationships": {
 		"requires": [

--- a/src/modules/border.js
+++ b/src/modules/border.js
@@ -11,16 +11,12 @@ export function registerBorderWrappers() {
 			/** @type boolean */
 			const fill_border = game.settings.get("hex-size-support", "fillBorder");
 			const options = {};
-			
-			/** @type boolean **/
-			const token_hide_border = this.document.getFlag("hex-size-support", "hideBorder");
 
 			if (always_show) options.hover = true;
-			
+
 			this.border.clear();
-			if (!this.isVisible || token_hide_border) return;
 			const borderColor = this._getBorderColor(options);
-			if (borderColor == null) return;
+			if (!borderColor) return;
 
 			const t = CONFIG.Canvas.objectBorderThickness;
 			this.border.position.set(this.document.x, this.document.y);
@@ -57,6 +53,29 @@ export function registerBorderWrappers() {
 			if (fill_border) {
 				this.border.beginFill(borderColor, 0.3).drawRoundedRect(0, 0, this.w, this.h, 3);
 			}
+		},
+		"OVERRIDE"
+	);
+
+	libWrapper.register(
+		"hex-size-support",
+		"Token.prototype._refreshVisibility",
+		/** @this Token */
+		function () {
+			this.visible = this.isVisible;
+
+			/** @type boolean */
+			const always_show = game.settings.get("hex-size-support", "alwaysShowBorder");
+			/** @type boolean **/
+			const token_hide_border = this.document.getFlag("hex-size-support", "hideBorder");
+
+			if (this.border)
+				this.border.visible =
+					!token_hide_border &&
+					this.visible &&
+					this.renderable &&
+					(always_show || this.controlled || this.hover || this.layer.highlightObjects) &&
+					!(this.document.disposition === CONST.TOKEN_DISPOSITIONS.SECRET && !this.isOwner);
 		},
 		"OVERRIDE"
 	);

--- a/src/modules/grid.js
+++ b/src/modules/grid.js
@@ -214,9 +214,9 @@ class HSSHexagonalGrid extends HexagonalGrid {
 		const shift_val = Math.floor((token_size + alt_shape - 1) / 2) % 2;
 		if (this.columnar) y += (shift_val * this.h) / 2;
 		else x += (shift_val * this.w) / 2;
-		const [r0, c0] = this._getGridPositionFromPixels(x, y, "round");
-		let [x0, y0] = this.getPixelsFromGridPosition(r0, c0);
-		[x0, y0] = this._adjustSnapForTokenSize(x0, y0, token);
+		const offset = HexagonalGrid.pixelsToOffset({x,y}, this.options, "round");
+		const point = HexagonalGrid.offsetToPixels(offset, this.options);
+		const [x0, y0] = this._adjustSnapForTokenSize(point.x, point.y, token);
 		return { x: x0, y: y0 };
 	}
 }

--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -197,7 +197,9 @@ function flipControlledTokens() {
 			),
 		};
 	});
-	canvas.scene?.updateEmbeddedDocuments("Token", updates);
+	canvas.scene?.updateEmbeddedDocuments("Token", updates).then(() => {
+		canvas.tokens?.controlled.forEach(t => t.draw());
+	});
 }
 
 /**


### PR DESCRIPTION
There are some problems with v11 compatibility currently.
 
- [x] Error in getSnappedPosition breaks movement on hex grids for tokens sized > 2
- [x] Rotating doesn't update the border until the token is interacted with.
- [x] Always show border doesn't work
- [x] CI Configuration is likely broken