### PR TITLE
Fix hook running on inactive scenes

### DIFF
--- a/src/modules/hitarea.js
+++ b/src/modules/hitarea.js
@@ -17,6 +17,7 @@ export function hitAreaDraw(token) {
 
 /** @param {TokenDocument} token */
 export function hitAreaUpdate(token, data) {
+	if (!token?.object) return;
 	if (
 		!["width", "height", "texture.scaleX", "texture.scaleY"].some(k => Object.hasOwn(data, k)) &&
 		foundry.utils.getProperty(data, "flags.hex-size-support.alternateOrientation") == null


### PR DESCRIPTION
For some reason, the hook to update the hitarea can run on inactive
scenes. This does a quick chec to make sure the token that is being
operated on exists and is drawn befor continuing

Fixes: #18
